### PR TITLE
Make Opsgenie Alert Level Configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,7 @@ kannel_monit_mailgun_domain:
 kannel_monit_mailgun_from_address:
 kannel_monit_mailgun_recipient:
 kannel_monit_opsgenie_api_key:
+kannel_monit_opsgenie_alert_priority: P3  # Check priority levels https://docs.opsgenie.com/docs/alert-priority-settings
 kannel_monit_setup_mode: false
 kannel_enable_monit: true
 kannel_monit_scripts: ["monit"]

--- a/templates/etc/monit/exec-scripts/smpp-connection-opsgenie-alerts.sh.j2
+++ b/templates/etc/monit/exec-scripts/smpp-connection-opsgenie-alerts.sh.j2
@@ -11,7 +11,7 @@ if [[ "$1" == "failed" ]]; then
         \"message\": \"$(hostname): monit - ${MONIT_SERVICE}\",
         \"alias\": \"monit-$(hostname)-${MONIT_SERVICE}\",
         \"description\":\"${MONIT_DESCRIPTION}\",
-        \"priority\":\"P4\",
+        \"priority\":\"{{ kannel_monit_opsgenie_alert_priority }}\",
         \"source\":\"$(hostname)\"
     }" |
             python3 -c "import sys, json; print(json.load(sys.stdin)['requestId'])")


### PR DESCRIPTION
Allow setting the preferred alert level for SMPP connection outage alerts to Opsgenie. Sets default to P3.