### PR TITLE
Allows Monit Fail Checks to Span Multiple Cycles

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,8 +33,10 @@ kannel_monit_check_host_name: kannel
 kannel_monit_check_host_address:
 kannel_monit_check_host_port:
 kannel_monit_check_host_type: TCP
-kannel_monit_check_times: 15
-kannel_monit_check_cycles: 15
+kannel_monit_success_check_cycles: 15  # number of Monit cycles to test whether a connection has been restored using monit
+kannel_monit_success_cycles_target: 15  # out of kannel_monit_success_check_cycles the number of tests that should be successfull to render a connection as restored
+kannel_monit_fail_check_cycles: 2  # number of Monit cycles to test whether a connection has been cut using monit
+kannel_monit_fail_cycles_target: 2  # out of kannel_monit_success_check_cycles the number of tests that should fail to render a connection as cut
 kannel_monit_check_interval: 20
 kannel_monit_mailgun_api_key:
 kannel_monit_mailgun_domain:

--- a/templates/etc/monit/conf.d/smpp-host-connection.j2
+++ b/templates/etc/monit/conf.d/smpp-host-connection.j2
@@ -1,8 +1,9 @@
 check host {{ kannel_monit_check_host_name }} with address {{kannel_monit_check_host_address}}
-    IF failed
+    IF FAILED
         port {{ kannel_monit_check_host_port }}
         type {{ kannel_monit_check_host_type }}
+    for {{ kannel_monit_fail_cycles_target }} times in {{ kannel_monit_fail_check_cycles }} cycles
     THEN
       exec "{{ kannel_monit_exec_scripts_path }}/{{ kannel_monit_exec_script_name }} failed"
-    ELSE IF SUCCEEDED for {{ kannel_monit_check_times }} times in {{ kannel_monit_check_cycles }} cycles THEN
+    ELSE IF SUCCEEDED for {{ kannel_monit_success_cycles_target }} times in {{ kannel_monit_success_check_cycles }} cycles THEN
       exec "{{ kannel_monit_exec_scripts_path }}/{{ kannel_monit_exec_script_name }} success"

--- a/templates/etc/monit/exec-scripts/smpp-connection-alerts.sh.j2
+++ b/templates/etc/monit/exec-scripts/smpp-connection-alerts.sh.j2
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ipsec_failure_file=/tmp/ipsec-failure-time
+test_duration_seconds={{ kannel_monit_success_check_cycles * kannel_monit_check_interval }}
 # If failed
 if [[ "$1" == "failed" ]] ; then
     # write the first failure incident to file
@@ -25,7 +26,9 @@ elif [[ "$1" == "success" ]] ; then
     first_incident_time_epoch=$(date +%s -d "${first_incident_time}")
     current_time_epoch=$(date +%s -d "${MONIT_DATE}")
     time_difference=$(expr ${current_time_epoch} - ${first_incident_time_epoch})
+    time_difference=$(expr ${time_difference} - ${test_duration_seconds})
     incident_duration=$(date '+%H hours, %M minutes and %S seconds' -ud @${time_difference})
+    test_duration=$(date '+%M minutes' -ud @${test_duration_seconds})
     # Close Opsgenie incident
     source "{{ kannel_monit_exec_scripts_path }}/{{ kannel_monit_opsgenie_exec_script_name }}"
 
@@ -35,7 +38,7 @@ elif [[ "$1" == "success" ]] ; then
         -F from="{{ kannel_monit_mailgun_from_address }}" \
         -F to="{{ kannel_monit_mailgun_recipient }}" \
         -F subject="$(hostname): {{ kannel_monit_check_host_name }} SMPP Connection" \
-        -F text="The {{ kannel_monit_check_host_name }} SMPP connection on the host $(hostname) has been restored at '$MONIT_DATE UTC'. The connection was down or intermittent for up to $incident_duration."
+        -F text="The {{ kannel_monit_check_host_name }} SMPP connection on the host $(hostname) has been registered as restored at '$MONIT_DATE UTC', following $test_duration of testing. The connection was down or intermittent for $incident_duration starting '$first_incident_time UTC'."
 
     # Clear failure incident file content
     :> "$ipsec_failure_file"


### PR DESCRIPTION
Allow Monit fail checks to span more than one cycle to cater for
scenarios where e.g. the SMPP connection is down for just seconds as a
VPN connection is restarted.

Signed-off-by: Jason Rogena <jason@rogena.me>